### PR TITLE
docs(readme): fix missing line continuation in jq example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jq -r '.data.items[] | [.emailId, (.subject // "")] | @tsv' /tmp/xin.inbox.json
 # 3) Filter by subject keyword (case-insensitive)
 jq -r '.data.items[]
   | select((.subject // "") | test("invoice"; "i"))
-  | {emailId, subject, from: (.from[0].email // null)}'
+  | {emailId, subject, from: (.from[0].email // null)}' \
   /tmp/xin.inbox.json
 ```
 


### PR DESCRIPTION
## Summary
- README 里第三个 jq 例子（filter by subject keyword）末尾的 `'` 后直接换行接 `/tmp/xin.inbox.json`，缺少 `\` 续行符。复制粘贴执行时 shell 会把 `/tmp/xin.inbox.json` 当成独立命令，导致示例跑不通。
- 加上一个反斜杠续行，让该示例与同一段中的其他多行命令风格一致。

## Test plan
- [x] `git diff` 仅一行变更
- [ ] 在 shell 里粘贴执行该例子，确认 jq 正确读取 `/tmp/xin.inbox.json`
