### PR TITLE
fix(ci): pin Stalwart image to v0.15.4 to unblock Smoke Test

### DIFF
--- a/tests/feature/stalwart/docker-compose.yml
+++ b/tests/feature/stalwart/docker-compose.yml
@@ -1,6 +1,14 @@
 services:
   stalwart:
-    image: stalwartlabs/stalwart:latest
+    # Pin to the last Stalwart release whose Docker image matches this harness.
+    # A floating :latest drifted to 0.16.x, which dropped the entrypoint that
+    # auto-loads our mounted config (via STALWART_PATH), moved the default config
+    # path to /etc/stalwart/config.json, and changed the fallback-admin auth
+    # contract so the plaintext secret in config.toml no longer authenticates
+    # (management API returned 401). That broke the Smoke Test seed step with
+    # "management API did not become ready". Upgrading the harness to 0.16.x is
+    # tracked separately; pin here to keep CI green and reproducible.
+    image: stalwartlabs/stalwart:v0.15.4
     container_name: xin-stalwart
     # Run as the host user so the bind-mounted .state directory is removable by the test runner.
     # (GitHub Actions Linux runners otherwise end up with root-owned files under .state.)


### PR DESCRIPTION
## Problem

The `Smoke Test` CI job started failing on every PR with:

```
error: stalwart seed failed: management API did not become ready
```

This is **infrastructure drift**, unrelated to any code change. `docker-compose.yml` used the floating tag `stalwartlabs/stalwart:latest`, which moved to **0.16.x** and changed the image's startup contract in three ways:

1. dropped the `entrypoint.sh` that auto-loaded our mounted config from `STALWART_PATH`;
2. moved the default config path to `/etc/stalwart/config.json`;
3. changed the `fallback-admin` auth contract — the plaintext `secret` in `config.toml` no longer authenticates (management API returns **401**).

The result: the container either started in bootstrap mode (no config found) or rejected the seed's admin credentials, so the management API on `:39090` never became usable and the seed readiness poll timed out.

## Fix

Pin the image to `stalwartlabs/stalwart:v0.15.4` — the last release whose Docker image matches this harness (config auto-load via `STALWART_PATH`, plaintext `fallback-admin`). No `--config` override is needed on this version.

> Note: simply adding `--config` on 0.16.7 was **not** enough — the 0.16.x `fallback-admin` plaintext secret still returned 401. Migrating the harness to 0.16.x (hashed admin secret / new config layout) is left as separate follow-up work.

## Verification

Reproduced the failure locally, then confirmed the fix end-to-end against the pinned `v0.15.4` image:

```
cargo run --bin xin-feature -- --fresh --case-dir tests/feature/stalwart/cases --all
```

→ **13/13** smoke cases pass, no bootstrap mode, exit 0.
